### PR TITLE
Added missing trigger "dot 1 long press"

### DIFF
--- a/Z2M-2.0/Ikea/Ikea-E2123-Generic.yaml
+++ b/Z2M-2.0/Ikea/Ikea-E2123-Generic.yaml
@@ -3,7 +3,6 @@ blueprint:
   description: >-
     This blueprint is for Ikea E2123 generic use.
   domain: automation
-
   input:
     remote:
       name: Remote
@@ -89,7 +88,7 @@ blueprint:
       selector:
         action:
       default: []
-  
+
     dots_1_long_press:
       name: Dots 1 long press
       description: Action to perform
@@ -124,7 +123,7 @@ blueprint:
       selector:
         action:
       default: []
-  
+
     dots_2_long_press:
       name: Dots 2 long press
       description: Action to perform
@@ -223,6 +222,13 @@ triggers:
   - domain: mqtt
     device_id: !input remote
     type: action
+    subtype: dots_1_long_press
+    id: dots_1_long_press
+    trigger: device
+
+  - domain: mqtt
+    device_id: !input remote
+    type: action
     subtype: dots_1_long_release
     id: dots_1_long_release
     trigger: device
@@ -307,7 +313,6 @@ actions:
             id:
               - volume_down
         sequence: !input volume_down
-
 
       - conditions:
           - condition: trigger


### PR DESCRIPTION
Hello @Dhy19971,
I tested today your awesome blueprint for the Symfonisk remote model 2123,, but while configuring it, I noticed that the Z2m trigger "dots_1_long_press" wasn't in the blueprint.
I noticed it because I want to use this trigger with my remote, and it wans't working. Is it possible to add it?

Thank you and hello from Switzerland 🇨🇭